### PR TITLE
Ensure the right Python version is available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,9 @@ install:
   # - git submodule update --remote  # versioneer does not work with submodules
   - git clone https://github.com/SHTOOLS/SHTOOLS.git
 
+  # Install new Python if necessary
+  - ps: .\multibuild\install_python.ps1
+
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -200,4 +200,4 @@ on_success:
   #- twine upload --repository-url https://test.pypi.org/legacy/ --username wieczor --password %PYPITEST_PASSWORD% --skip-existing dist/*
 
 artifacts:
-  - path: '%APPVEYOR_BUILD_FOLDER%\SHTOOLS\dist\pyshtools-*.whl'
+  - path: SHTOOLS\dist\pyshtools-*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ platform:
   - x64
 
 image:
-  - Visual Studio 2019
+  - Visual Studio 2015
 
 environment:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,6 +105,7 @@ install:
   # Get needed submodules
   # - git submodule update --remote  # versioneer does not work with submodules
   - git clone https://github.com/SHTOOLS/SHTOOLS.git
+  - git clone https://github.com/multi-build/multibuild.git
 
   # Install new Python if necessary
   - ps: .\multibuild\install_python.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -200,4 +200,4 @@ on_success:
   #- twine upload --repository-url https://test.pypi.org/legacy/ --username wieczor --password %PYPITEST_PASSWORD% --skip-existing dist/*
 
 artifacts:
-  - path: dist\pyshtools-*.whl
+  - path: '%APPVEYOR_BUILD_FOLDER%\SHTOOLS\dist\pyshtools-*.whl'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -198,3 +198,6 @@ on_success:
   - pip install twine
   - twine upload --username wieczor --password %PYPI_PASSWORD% --skip-existing dist/*
   #- twine upload --repository-url https://test.pypi.org/legacy/ --username wieczor --password %PYPITEST_PASSWORD% --skip-existing dist/*
+
+artifacts:
+  - path: dist\pyshtools-*.whl


### PR DESCRIPTION
Roll back the AppVeyor image to the default of "Visual Studio 2015" in order to have mingw-w64 6.3.0 available for the `libgfortran-3.dll` library required by `liblapack.dll`. The "Visual Studio 2015" image however does not include Python 3.9, so the `multibuild/install-python.ps1` script installs it. 

Hopefully this addresses SHTOOLS/SHTOOLS#319.